### PR TITLE
Updated build script.

### DIFF
--- a/INSTALL_UBUNTU.README
+++ b/INSTALL_UBUNTU.README
@@ -1,0 +1,72 @@
+*********************************************
+INSTALL_UBUNTU.README
+
+This document gives simplified instructions for installing HeeksCAD and its related plugins 
+and libraries on Ubuntu.
+
+********************************************
+TESTED VERSIONS
+
+This procedure and the related convenience script has been tested on the following distributions
+and versions but may work on other .deb based distros as well:
+
+Ubuntu 11.04 (Natty)
+LinuxMint 11 (Katya)
+
+
+*******************************************
+OBTAINING THE SOURCE CODE
+
+The project pages for HeeksCAD and the related projects are found on github.
+
+HeeksCAD: https://github.com/Heeks/heekscad
+HeeksCNC: https://github.com/Heeks/heekscnc
+libarea: https://github.com/Heeks/libarea
+
+HeeksCAD and HeeksCNC also have dependencies
+Opencamlib:  https://github.com/aewallin/opencamlib
+Opencascade Community Edition (OCE): https://github.com/tpaviot/oce
+
+The automated build script assumes all this source is available and arranged in a specific configuration.
+
+Assuming git is installed on your machine, this command will create all the repositories in the correct structure and
+pull source from all the projects repos.
+
+git clone --recursive git://github.com/Heeks/heekscad.git
+
+********************************************
+Building and Installing
+  
+The file INSTALL_UBUNTU.sh in the ~/heekscad directory will first install dependencies, then 
+recurse through all of the projects, configure, build, and install them.
+
+run the command from a terminal window like this: 
+
+sh INSTALL_UBUNTU.sh
+
+Several of the commands run with sudo privelege so it will prompt for a password.    
+Building the libraries, particularly OCE can take a LONG time.  Make a sandwich.
+
+If everything completes normally, you should be able to start heekscad from the command line or the menu.
+
+If you get an error like this:
+  error while loading shared libraries: libTKVRML.so.1....
+
+enter this command in a terminal window:
+
+sudo ldconfig
+
+
+***********************************************
+UPGRADING 
+
+If you wish to upgrade later, enter these commands from the heekscad directory:
+git pull
+git submodule update
+
+Then re-run the script to rebuild and install.
+
+
+
+
+

--- a/INSTALL_UBUNTU.sh
+++ b/INSTALL_UBUNTU.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+# heekscad-install.sh -- Downloads, builds and installs HeeksCAD from svn
+
+BUILDPATH=~             # Location of HeeksCAD build dir
+BUILDPREREQS="libwxbase2.8-dev cmake \
+  build-essential libwxgtk2.8 libwxgtk2.8-dev ftgl-dev\
+  libgtkglext1-dev python-dev cmake libboost-python-dev"
+
+# Install build prerequisites
+# The next two lines can be commented out after the initial run.
+sudo apt-get update
+sudo apt-get install -y $BUILDPREREQS
+
+cd ${BUILDPATH}/heekscad/heekscnc/oce
+if [ -d build]; then
+  cd build
+else
+  mkdir build
+  cd build
+fi
+cmake ..
+make 
+sudo make install
+
+cd ${BUILDPATH}/heekscad/
+cmake .
+make package
+sudo dpkg -i heekscad_*.deb
+
+# Install HeeksCNC
+cd ${BUILDPATH}/heekscad/heekscnc/
+cmake .
+make package
+sudo dpkg -i heekscnc_*.deb
+
+# Install libarea
+# area.so is required for pocket operations.
+#Get the libarea files from the SVN repository, build, and install
+cd ${BUILDPATH}/heekscad/heekscnc/libarea/
+make clean
+make
+sudo make install
+sudo ln -s .libs/area.so ${BUILDPATH}/heekscad/heekscnc/area.so
+
+# Install libactp
+#cd ${BUILDPATH}/heekscad/heekscnc/libactp/PythonLib
+#make clean
+#make
+#sudo make install
+#sudo ln -s .libs/actp.so ${BUILDPATH}/heekscad/heekscnc/actp.so
+
+# Install opencamlib
+cd ${BUILDPATH}/heekscad/heekscnc/opencamlib/src
+cmake .
+make
+make doc        # Creates PDF file needed by make install
+sudo make install


### PR DESCRIPTION
This build script removes opencascade as a dependency and adds a section
to build and install OCE.

This should eliminate the common 'FindOCE' warning that cmake was throwing 
